### PR TITLE
docs: add DigitalOcean setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,31 @@ To start the app
   * Start Phoenix endpoint with `mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+
+## Running on Ubuntu (DigitalOcean)
+
+To boot the demo on a fresh Ubuntu server:
+
+1. **Install system dependencies**
+   ```bash
+   sudo apt update
+   sudo apt install -y git curl build-essential nodejs npm erlang elixir
+   ```
+2. **Clone the project and install Elixir/Node packages**
+   ```bash
+   git clone https://github.com/<your-account>/ease-video.git
+   cd ease-video
+   mix local.hex --force
+   mix deps.get
+   npm --prefix assets install
+   ```
+3. **Allow web traffic on port 4000** (optional if using UFW)
+   ```bash
+   sudo ufw allow 4000/tcp
+   ```
+4. **Start the Phoenix server**
+   ```bash
+   MIX_ENV=prod mix phx.server
+   ```
+
+Navigate to `http://<server-ip>:4000` in your browser to load the app.


### PR DESCRIPTION
## Summary
- document how to install dependencies and run the Phoenix demo on a fresh Ubuntu DigitalOcean droplet

## Testing
- `mix deps.get` *(fails: Unknown package phoenix in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_689dd69cf6b0832e82f0dc276a1bb51d